### PR TITLE
Move runners into their own subnets

### DIFF
--- a/.templates/aws/jobs.yml
+++ b/.templates/aws/jobs.yml
@@ -187,7 +187,7 @@ jobs:
   instances: 1
   .: (( inject meta.jobs.runner ))
   networks:
-  - name: cf1
+  - name: runner1
   properties:
     metron_agent:
       zone: z1
@@ -198,7 +198,7 @@ jobs:
   instances: 1
   .: (( inject meta.jobs.runner ))
   networks:
-  - name: cf2
+  - name: runner2
   properties:
     metron_agent:
       zone: z2

--- a/.templates/aws/networks.yml
+++ b/.templates/aws/networks.yml
@@ -38,6 +38,39 @@ networks:
     cloud_properties:
       security_groups: (( grab meta.security_groups ))
       subnet: (( param "Enter the AWS subnet ID for this subnet" ))
+- name: runner1
+  type: manual
+  subnets:
+  - range: (( param "Enter the CIDR address for this subnet" ))
+    gateway: (( param "Enter the Gateway for this subnet" ))
+    dns: (( grab meta.dns ))
+    static: (( param "Enter the static IP ranges for this subnet" ))
+    reserved: (( param "Enter the reserved IP ranges for this subnet" ))
+    cloud_properties:
+      security_groups: (( grab meta.security_groups ))
+      subnet: (( param "Enter the AWS subnet ID for this subnet" ))
+- name: runner2
+  type: manual
+  subnets:
+  - range: (( param "Enter the CIDR address for this subnet" ))
+    gateway: (( param "Enter the Gateway for this subnet" ))
+    dns: (( grab meta.dns ))
+    static: (( param "Enter the static IP ranges for this subnet" ))
+    reserved: (( param "Enter the reserved IP ranges for this subnet" ))
+    cloud_properties:
+      security_groups: (( grab meta.security_groups ))
+      subnet: (( param "Enter the AWS subnet ID for this subnet" ))
+- name: runner3
+  type: manual
+  subnets:
+  - range: (( param "Enter the CIDR address for this subnet" ))
+    gateway: (( param "Enter the Gateway for this subnet" ))
+    dns: (( grab meta.dns ))
+    static: (( param "Enter the static IP ranges for this subnet" ))
+    reserved: (( param "Enter the reserved IP ranges for this subnet" ))
+    cloud_properties:
+      security_groups: (( grab meta.security_groups ))
+      subnet: (( param "Enter the AWS subnet ID for this subnet" ))
 - name: router1
   type: manual
   subnets:


### PR DESCRIPTION
Move runners into their own subnets according to the [codex network plan](https://github.com/starkandwayne/codex/blob/master/network.md).

Note: You need to define the 3 runner's networks, but only 2 are effectively used. I decided to do this because only 2 loggregator zones are defined. 
