### PR TITLE
replace period in directory keys with dash

### DIFF
--- a/.templates/bosh-lite/properties.yml
+++ b/.templates/bosh-lite/properties.yml
@@ -2,6 +2,7 @@
 meta:
   cf:
     base_domain: bosh-lite.com # override this if non-traditional bosh-lite
+    directory_key_prefix: bosh-lite-com #Replace period with dash in base_domain
     system_domain_organization: system
 
     consul:

--- a/global/properties.yml
+++ b/global/properties.yml
@@ -2,6 +2,7 @@
 meta:
   cf:
     base_domain: (( param "Enter the Cloud Foundry base domain" ))
+    directory_key_prefix: (( param "Replace period in Cloud Foundry base domain with dash" ))
     apps_domains: [ (( concat "run." meta.cf.base_domain )) ]
     system_domain: (( concat "system." meta.cf.base_domain ))
     creds:
@@ -142,7 +143,7 @@ properties:
     broker_client_timeout_seconds: 70
     buildpacks:
       .: (( inject meta.cf.blobstore_config ))
-      buildpack_directory_key: (( concat meta.cf.base_domain "-cc-buildpacks" ))
+      buildpack_directory_key: (( concat meta.cf.directory_key_prefix "-cc-buildpacks" ))
     bulk_api_password: (( grab meta.cf.creds.cc.bulk_api_password ))
     client_max_body_size: 15M
     db_encryption_key: (( grab meta.cf.creds.cc.db_encryption_key ))
@@ -187,7 +188,7 @@ properties:
     disable_custom_buildpacks: false
     droplets:
       .: (( inject meta.cf.blobstore_config ))
-      droplet_directory_key: (( concat meta.cf.base_domain "-cc-droplets" ))
+      droplet_directory_key: (( concat meta.cf.directory_key_prefix "-cc-droplets" ))
       max_staged_droplets_stored: null
     external_host: api
     external_port: 9022
@@ -237,7 +238,7 @@ properties:
     min_recommended_cli_version: null
     packages:
       .: (( inject meta.cf.blobstore_config ))
-      app_package_directory_key: (( concat meta.cf.base_domain "-cc-packages" ))
+      app_package_directory_key: (( concat meta.cf.directory_key_prefix "-cc-packages" ))
       max_package_size: 1073741824
       max_valid_packages_stored: null
     quota_definitions:
@@ -250,7 +251,7 @@ properties:
     reserved_private_domains: null
     resource_pool:
       .: (( inject meta.cf.blobstore_config ))
-      resource_directory_key: (( concat meta.cf.base_domain "-cc-resources" ))
+      resource_directory_key: (( concat meta.cf.directory_key_prefix "-cc-resources" ))
     security_event_logging:
       enabled: null
     security_group_definitions:


### PR DESCRIPTION
To deploy CF in aws, for `buildpack_directory_key`, `droplet_directory_key`,`app_package_directory_key` and `resource_directory_key`,  we suppose to configure using bucket names. In this repo,  take `buildpack_directory_key` for example, we configure it as `(( concat meta.cf.base_domain "-cc-buildpack")) which is a good idea to include base_domain. However, s3 bucket does not like period in their names. So I replaced period with dash to still keep base_domain there still.

In this page, it explained no period in s3 bucket name.
https://docs.cloudfoundry.org/deploying/common/cc-blobstore-config.html
