### PR TITLE
AWS: Move access_z* from cf* to router* networks

### DIFF
--- a/.templates/aws/jobs.yml
+++ b/.templates/aws/jobs.yml
@@ -336,7 +336,7 @@ jobs:
   instances: 1
   .: (( inject meta.jobs.access ))
   networks:
-  - name: cf1
+  - name: router1
   resource_pool: access_z1
   properties:
     metron_agent:
@@ -345,7 +345,7 @@ jobs:
   instances: 1
   .: (( inject meta.jobs.access ))
   networks:
-  - name: cf2
+  - name: router2
   resource_pool: access_z2
   properties:
     metron_agent:


### PR DESCRIPTION
- This will get your instances healthy again in the ELB.
- This will also allow you to actually run `cf ssh <app-name>`.
- This is also how it's configured in `.templates/google/jobs.yml`.

See related issue: https://github.com/starkandwayne/codex/issues/75