### PR TITLE
Move the access vms to the same network as brain

### DIFF
--- a/.templates/aws/jobs.yml
+++ b/.templates/aws/jobs.yml
@@ -368,7 +368,7 @@ jobs:
   instances: 1
   .: (( inject meta.jobs.access ))
   networks:
-  - name: router1
+  - name: cf1
   resource_pool: access_z1
   properties:
     metron_agent:
@@ -377,7 +377,7 @@ jobs:
   instances: 1
   .: (( inject meta.jobs.access ))
   networks:
-  - name: router2
+  - name: cf2
   resource_pool: access_z2
   properties:
     metron_agent:


### PR DESCRIPTION
Fixes a cf ssh bug by allowing access VMs traffic to go through nat hosts properly.