### PR TITLE
add db_connection_string config for bosh-lite

### DIFF
--- a/.templates/bosh-lite/properties.yml
+++ b/.templates/bosh-lite/properties.yml
@@ -97,3 +97,7 @@ properties:
     - host all all ::/0 md5
     replication:
       enabled: false
+  diego:
+    bbs:
+      sql:
+        db_connection_string: (( concat meta.cf.diegodb.scheme "://" meta.cf.diegodb.user ":" meta.cf.diegodb.pass "@" meta.cf.diegodb.host ":" meta.cf.diegodb.port "/" meta.cf.diegodb.dbname ))

--- a/global/properties.yml
+++ b/global/properties.yml
@@ -102,7 +102,7 @@ meta:
     uaadb:
       host: (( param "What hostname/IP is the uaadb available at?" ))
       port: (( param "What port is the uaadb listening on?" ))
-      scheme: (( param "Specify the type of database the uaadb is (postgres, mysql)" ))
+      scheme: (( param "Specify the type of database the uaadb is (postgresql, mysql)" ))
       user: (( param "Specify the user to connect to the uaadb" ))
       pass: (( param "Specify the password of the uaadb user" ))
       dbname: uaadb


### PR DESCRIPTION
Make bosh-lite can be directly deployed again